### PR TITLE
Upgrade to Android API 36 (Android 16) for the Play targetSdk deadline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ local.properties
 /.idea/runConfigurations.xml
 /app/release
 /.env
+
+# Kotlin compiler session markers
+.kotlin/

--- a/ads/src/main/java/tss/t/ads/NativeAdLoader.kt
+++ b/ads/src/main/java/tss/t/ads/NativeAdLoader.kt
@@ -21,8 +21,8 @@ import com.applovin.mediation.MaxError
 import com.applovin.mediation.nativeAds.MaxNativeAdListener
 import com.applovin.mediation.nativeAds.MaxNativeAdLoader
 import com.applovin.mediation.nativeAds.MaxNativeAdView
-import com.google.firebase.crashlytics.ktx.crashlytics
-import com.google.firebase.ktx.Firebase
+import com.google.firebase.crashlytics.crashlytics
+import com.google.firebase.Firebase
 import tss.t.securedtoken.NativeLib
 import tss.t.sharedfirebase.TSAnalytics
 import tss.t.sharedlibrary.utils.LocalRemoteConfig

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.google.firebase.appdistribution.gradle.firebaseAppDistribution
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import java.util.Properties
 import java.io.FileInputStream
@@ -89,6 +90,7 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
+        isCoreLibraryDesugaringEnabled = true
     }
     kotlin {
         compilerOptions {
@@ -110,6 +112,8 @@ composeCompiler {
 }
 
 dependencies {
+
+    coreLibraryDesugaring(libs.desugar.jdk.libs)
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -23,3 +23,7 @@
 -keep class tss.t.coreradio.models.** { *; }
 -keep class tss.t.coreapi.models.** { *; }
 -keep class tss.t.core.** { *; }
+# AppLovin bundles the IAB OMID SDK, which optionally calls into Amazon's PrivacyPass
+# attestation library. That library is not a dependency of this app, so R8 only needs to
+# stop warning about the unresolved references.
+-dontwarn com.amazon.privacypass.**

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,11 +4,8 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
-    <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <application
         android:name=".App"
@@ -17,7 +14,6 @@
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
-        android:requestLegacyExternalStorage="true"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Podcast"

--- a/app/src/main/java/tss/t/podcast/App.kt
+++ b/app/src/main/java/tss/t/podcast/App.kt
@@ -1,8 +1,8 @@
 package tss.t.podcast
 
 import com.google.firebase.FirebaseApp
-import com.google.firebase.ktx.Firebase
-import com.google.firebase.messaging.ktx.messaging
+import com.google.firebase.Firebase
+import com.google.firebase.messaging.messaging
 import dagger.hilt.android.HiltAndroidApp
 import tss.t.ads.ApplovinSdkWrapper
 import tss.t.core.CoreApp

--- a/app/src/main/java/tss/t/podcast/MainActivity.kt
+++ b/app/src/main/java/tss/t/podcast/MainActivity.kt
@@ -2,8 +2,11 @@
 
 package tss.t.podcast
 
+import android.Manifest
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.graphics.Color
+import android.os.Build
 import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.ComponentActivity
@@ -11,6 +14,7 @@ import androidx.activity.OnBackPressedCallback
 import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibilityScope
@@ -46,6 +50,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
+import androidx.core.app.ActivityCompat
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
@@ -96,6 +101,7 @@ class MainActivity : ComponentActivity() {
 
     private var navHostController: NavHostController? = null
     private var homeInnerNavHostController: NavHostController? = null
+    private var onBackPressedCallback: OnBackPressedCallback? = null
 
     @OptIn(ExperimentalSharedTransitionApi::class, ExperimentalMaterial3Api::class)
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -104,9 +110,13 @@ class MainActivity : ComponentActivity() {
             statusBarStyle = SystemBarStyle.light(
                 scrim = Color.TRANSPARENT,
                 darkScrim = Color.TRANSPARENT
+            ),
+            navigationBarStyle = SystemBarStyle.light(
+                scrim = Color.TRANSPARENT,
+                darkScrim = Color.TRANSPARENT
             )
         )
-        val onBackPressedCallback = object : OnBackPressedCallback(true) {
+        val backCallback = object : OnBackPressedCallback(true) {
             override fun handleOnBackPressed() {
                 if (navHostController?.currentBackStackEntry?.destination?.route == TSRouter.Main.route) {
                     if (homeInnerNavHostController?.currentBackStackEntry?.destination?.route == TSHomeRouter.Discover.route) {
@@ -119,8 +129,10 @@ class MainActivity : ComponentActivity() {
                 }
             }
         }
-        onBackPressedDispatcher.addCallback(onBackPressedCallback)
+        onBackPressedCallback = backCallback
+        onBackPressedDispatcher.addCallback(this, backCallback)
         handleIntent(intent)
+        requestNotificationPermissionIfNeeded()
         setContent {
             val listState = remember {
                 mutableStateMapOf<BottomBarTab, LazyListState>()
@@ -164,7 +176,7 @@ class MainActivity : ComponentActivity() {
         lifecycleScope.launch {
             mainViewModel.event.collect {
                 when (it) {
-                    HomeEvent.ExitApp -> finish()
+                    HomeEvent.ExitApp -> exitToHome()
                     HomeEvent.ToastDoubleClickToExit -> Toast.makeText(
                         this@MainActivity,
                         R.string.double_click_to_exit,
@@ -196,6 +208,34 @@ class MainActivity : ComponentActivity() {
                 playerViewModel.onRestoreFromNotification(mediaId)
             }
         }
+    }
+
+    private val requestNotificationPermission =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { /* no-op */ }
+
+    /**
+     * POST_NOTIFICATIONS is declared in the manifest but was never requested, so on API 33+ the
+     * media and FCM notifications were silently dropped on a fresh install.
+     */
+    private fun requestNotificationPermissionIfNeeded() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return
+        val granted = ActivityCompat.checkSelfPermission(
+            this,
+            Manifest.permission.POST_NOTIFICATIONS
+        ) == PackageManager.PERMISSION_GRANTED
+        if (granted || shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS)) {
+            return
+        }
+        requestNotificationPermission.launch(Manifest.permission.POST_NOTIFICATIONS)
+    }
+
+    /**
+     * Hands the back press back to the system instead of calling finish(), so the platform can run
+     * its own back-to-home animation (predictive back is on by default from targetSdk 36).
+     */
+    private fun exitToHome() {
+        onBackPressedCallback?.isEnabled = false
+        onBackPressedDispatcher.onBackPressed()
     }
 
     private var _pendingExitApp = false

--- a/app/src/main/java/tss/t/podcast/ui/screens/discorver/widgets/Indicator.kt
+++ b/app/src/main/java/tss/t/podcast/ui/screens/discorver/widgets/Indicator.kt
@@ -12,7 +12,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
 import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults.PositionalThreshold
 import androidx.compose.material3.pulltorefresh.PullToRefreshState
-import androidx.compose.material3.pulltorefresh.pullToRefreshIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.derivedStateOf
@@ -51,14 +50,12 @@ fun Indicator(
     color: Color = PullToRefreshDefaults.indicatorColor,
     threshold: Dp = PositionalThreshold,
 ) {
-    Box(
-        modifier = modifier.pullToRefreshIndicator(
-            state = state,
-            isRefreshing = isRefreshing,
-            containerColor = containerColor,
-            threshold = threshold,
-        ),
-        contentAlignment = Alignment.Center
+    PullToRefreshDefaults.IndicatorBox(
+        state = state,
+        isRefreshing = isRefreshing,
+        modifier = modifier,
+        maxDistance = threshold,
+        containerColor = containerColor,
     ) {
         Crossfade(
             targetState = isRefreshing,

--- a/app/src/main/java/tss/t/podcast/ui/screens/player/widgets/PlayerArea.kt
+++ b/app/src/main/java/tss/t/podcast/ui/screens/player/widgets/PlayerArea.kt
@@ -43,13 +43,9 @@ import java.util.Locale
 
 @Composable
 fun rememberStatusBarHeight(): Int {
-    val density = LocalDensity.current
-    val statusBar = WindowInsets.statusBars
-    return remember {
-        with(density) {
-            statusBar.getTop(density)
-        }
-    }
+    // Read live: insets are frequently 0 on the first frame under enforced edge-to-edge, and they
+    // change on rotation/config change. Caching this in a keyless remember() froze the wrong value.
+    return WindowInsets.statusBars.getTop(LocalDensity.current)
 }
 
 
@@ -100,7 +96,7 @@ fun BoxScope.PlayerArea(
     // Padding
     val statusBarPadding = rememberStatusBarHeight()
 
-    LaunchedEffect(playerSize) {
+    LaunchedEffect(playerSize, statusBarPadding) {
         onPlayerSizeChanged(playerSize - statusBarPadding)
     }
 

--- a/app/src/main/java/tss/t/podcast/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/tss/t/podcast/ui/screens/search/SearchScreen.kt
@@ -221,7 +221,6 @@ fun EmptySearchWidget(
     modifier: Modifier = Modifier,
     searchText: String?
 ) {
-    val context = LocalContext.current
     Column(
         modifier,
         horizontalAlignment = Alignment.CenterHorizontally
@@ -233,7 +232,7 @@ fun EmptySearchWidget(
         )
         Text(
             buildAnnotatedString {
-                append(context.getString(R.string.empty_search_title))
+                append(stringResource(R.string.empty_search_title))
                 withStyle(TextStyles.Title5.toSpanStyle()) {
                     append(searchText)
                 }

--- a/app/src/main/java/tss/t/podcast/ui/theme/Theme.kt
+++ b/app/src/main/java/tss/t/podcast/ui/theme/Theme.kt
@@ -3,7 +3,7 @@ package tss.t.podcast.ui.theme
 import android.os.Build
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.ExperimentalSharedTransitionApi
-import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.animation.SharedTransitionLayout
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
@@ -54,11 +54,11 @@ fun PodcastThemePreview(
     content: @Composable () -> Unit
 ) {
     val scope = CoroutineScope(Dispatchers.Default)
-    SharedTransitionScope {
+    SharedTransitionLayout {
         AnimatedContent(true, label = "") {
             if (it) {
                 CompositionLocalProvider(
-                    LocalSharedTransitionScope provides this@SharedTransitionScope,
+                    LocalSharedTransitionScope provides this@SharedTransitionLayout,
                     LocalNavAnimatedVisibilityScope provides this,
                     LocalAnalyticsScope provides TSAnalytics(
                         context = LocalContext.current,

--- a/featureOnboarding/build.gradle.kts
+++ b/featureOnboarding/build.gradle.kts
@@ -54,6 +54,8 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.material.icons)
+    implementation(libs.material.icons.extended)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,46 +1,40 @@
 [versions]
-agp = "8.11.0"
-compileSdk = "35"
+agp = "8.13.2"
+compileSdk = "36"
 minSdk = "24"
-targetSdk = "35"
-applovinqualityservicegradleplugin = "+"
-applovinSdk = "13.3.1"
+targetSdk = "36"
+applovinqualityservicegradleplugin = "5.12.9"
+applovinSdk = "13.6.4"
 coil = "2.7.0"
 dotsindicatorVersion = "5.1.0"
-facebookAndroidSdk = "18.0.3"
-firebaseBom = "33.16.0"
+facebookAndroidSdk = "18.3.0"
+firebaseBom = "34.17.0"
 fragmentKtx = "1.8.8"
 gson = "2.13.1"
-coreKtx = "1.16.0"
+coreKtx = "1.18.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
 kotlinxCoroutinesTest = "1.10.2"
-lifecycleRuntimeKtx = "2.9.1"
-activityCompose = "1.10.1"
-composeBom = "2025.06.01"
+lifecycleRuntimeKtx = "2.10.0"
+activityCompose = "1.13.0"
+composeBom = "2026.06.01"
 appcompat = "1.7.1"
 loggingInterceptor = "5.1.0"
-material = "1.8.3"
-material-icons-core="1.7.8"
-material-icons-extended="1.7.8"
-materialVersion = "1.12.0"
-media3Exoplayer = "1.7.1"
-navigationCompose = "2.9.1"
+materialVersion = "1.13.0"
+media3Exoplayer = "1.10.1"
+navigationCompose = "2.9.8"
 okhttp = "5.1.0"
 retrofit = "3.0.0"
 hilt = "2.56.2"
 junitJupiter = "5.13.3"
-roomPaging = "2.7.2"
-uiTooling = "1.8.3"
-securityCryptoKtx = "1.0.0"
-lifecycleProcess = "2.9.1"
+roomPaging = "2.8.4"
+securityCryptoKtx = "1.1.0"
+lifecycleProcess = "2.10.0"
 jsoupVer = "1.21.1"
-uiGraphicsAndroid = "1.8.3"
-playServicesWallet = "19.4.0"
-lifecycleViewmodelKtx = "2.9.1"
-lifecycleLivedataKtx = "2.9.1"
 dagger = "2.56.2"
+collection = "1.6.0"
+desugarJdkLibs = "2.1.5"
 #kotlin
 kotlin = "2.2.0"
 #ksp
@@ -71,10 +65,10 @@ androidx-room-testing = { module = "androidx.room:room-testing", version.ref = "
 applovin-sdk = { module = "com.applovin:applovin-sdk", version.ref = "applovinSdk" }
 applovinqualityservicegradleplugin = { module = "com.applovin.quality:AppLovinQualityServiceGradlePlugin", version.ref = "applovinqualityservicegradleplugin" }
 facebook-android-sdk = { module = "com.facebook.android:facebook-android-sdk", version.ref = "facebookAndroidSdk" }
-firebase-analytics-ktx = { module = "com.google.firebase:firebase-analytics-ktx" }
+firebase-analytics-ktx = { module = "com.google.firebase:firebase-analytics" }
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
 firebase-config = { module = "com.google.firebase:firebase-config" }
-firebase-crashlytics-ktx = { module = "com.google.firebase:firebase-crashlytics-ktx" }
+firebase-crashlytics-ktx = { module = "com.google.firebase:firebase-crashlytics" }
 firebase-messaging-ktx = { module = "com.google.firebase:firebase-messaging" }
 firebase-remote-config = { module = "com.google.firebase:firebase-config" }
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
@@ -90,14 +84,15 @@ androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
-androidx-material3 = { group = "androidx.compose.material3", name = "material3", version = "1.3.2" }
+androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
-material-icons = { group = "androidx.compose.material", name = "material-icons-core", version.ref = "material-icons-core" }
-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended", version.ref = "material-icons-extended" }
-material = { group = "androidx.compose.material", name = "material", version.ref = "material" }
+material-icons = { group = "androidx.compose.material", name = "material-icons-core" }
+material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
+material = { group = "androidx.compose.material", name = "material" }
 google-material = { group = "com.google.android.material", name = "material", version.ref = "materialVersion" }
-androidx-collection = "androidx.collection:collection:1.5.0"
+androidx-collection = { group = "androidx.collection", name = "collection", version.ref = "collection" }
+desugar-jdk-libs = { group = "com.android.tools", name = "desugar_jdk_libs", version.ref = "desugarJdkLibs" }
 
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-android-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }
@@ -118,14 +113,10 @@ junit-jupiter = { group = "org.junit.jupiter", name = "junit-jupiter", version.r
 
 coil = { module = "io.coil-kt:coil", version.ref = "coil" }
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling", version.ref = "uiTooling" }
 androidx-security-crypto-ktx = { group = "androidx.security", name = "security-crypto", version.ref = "securityCryptoKtx" }
 androidx-lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "lifecycleProcess" }
 jsoup = { group = "org.jsoup", name = "jsoup", version.ref = "jsoupVer" }
-androidx-ui-graphics-android = { group = "androidx.compose.ui", name = "ui-graphics-android", version.ref = "uiGraphicsAndroid" }
-play-services-wallet = { group = "com.google.android.gms", name = "play-services-wallet", version.ref = "playServicesWallet" }
-androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "lifecycleViewmodelKtx" }
-androidx-lifecycle-livedata-ktx = { group = "androidx.lifecycle", name = "lifecycle-livedata-ktx", version.ref = "lifecycleLivedataKtx" }
+androidx-ui-graphics-android = { group = "androidx.compose.ui", name = "ui-graphics-android" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -134,9 +125,9 @@ android-library = { id = "com.android.library", version.ref = "agp" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 dagger-hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 kotlin-serilization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
-google-services = { id = "com.google.gms.google-services", version = "4.4.3" }
-firebase-crashlytics = { id = "com.google.firebase.crashlytics", version = "3.0.4" }
-firebase-appdistribution = { id = "com.google.firebase.appdistribution", version = "5.1.1" }
+google-services = { id = "com.google.gms.google-services", version = "4.5.0" }
+firebase-crashlytics = { id = "com.google.firebase.crashlytics", version = "3.0.7" }
+firebase-appdistribution = { id = "com.google.firebase.appdistribution", version = "5.3.0" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 room = { id = "androidx.room", version.ref = "roomPaging" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sat Sep 07 17:09:44 ICT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/samples/build.gradle.kts
+++ b/samples/build.gradle.kts
@@ -57,6 +57,8 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.material.icons)
+    implementation(libs.material.icons.extended)
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.runtime.ktx)

--- a/securedToken/build.gradle.kts
+++ b/securedToken/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 
 android {
     namespace = "tss.t.securedtoken"
+    ndkVersion = "27.0.12077973"
     compileSdk = libs.versions.compileSdk.get().toInt()
 
     defaultConfig {

--- a/sharedFirebase/src/main/java/tss/t/sharedfirebase/TSAnalytics.kt
+++ b/sharedFirebase/src/main/java/tss/t/sharedfirebase/TSAnalytics.kt
@@ -9,8 +9,8 @@ import android.os.Build
 import android.os.Bundle
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.core.os.bundleOf
-import com.google.firebase.analytics.ktx.analytics
-import com.google.firebase.ktx.Firebase
+import com.google.firebase.analytics.analytics
+import com.google.firebase.Firebase
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch

--- a/sharedFirebase/src/main/java/tss/t/sharedfirebase/TSFirebaseRemoteConfig.kt
+++ b/sharedFirebase/src/main/java/tss/t/sharedfirebase/TSFirebaseRemoteConfig.kt
@@ -2,8 +2,8 @@ package tss.t.sharedfirebase
 
 import android.content.Context
 import androidx.compose.runtime.staticCompositionLocalOf
-import com.google.firebase.ktx.Firebase
-import com.google.firebase.remoteconfig.ktx.remoteConfig
+import com.google.firebase.Firebase
+import com.google.firebase.remoteconfig.remoteConfig
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay

--- a/sharedPlayer/src/main/java/tss/t/sharedplayer/notifications/TSNotificationProvider.kt
+++ b/sharedPlayer/src/main/java/tss/t/sharedplayer/notifications/TSNotificationProvider.kt
@@ -52,7 +52,7 @@ class TSNotificationProvider @Inject constructor(
         onNotificationChangedCallback: MediaNotification.Provider.Callback
     ): MediaNotification {
         val currentMediaItem = mediaSession.player.currentMediaItem!!
-        val channelId = "123"
+        val channelId = CHANNEL_ID
         NotificationUtils.createChannelIfNeeded(context, channelId)
         val notificationBuilder = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             Notification.Builder(context, channelId)
@@ -133,7 +133,7 @@ class TSNotificationProvider @Inject constructor(
             mediaStyle.setCancelButtonIntent(
                 actionFactory.createMediaActionPendingIntent(
                     mediaSession,
-                    Player.COMMAND_STOP.toLong()
+                    Player.COMMAND_STOP
                 )
             )
         }
@@ -165,7 +165,7 @@ class TSNotificationProvider @Inject constructor(
                 .setDeleteIntent(
                     actionFactory.createMediaActionPendingIntent(
                         mediaSession,
-                        Player.COMMAND_STOP.toLong()
+                        Player.COMMAND_STOP
                     )
                 )
                 .setOnlyAlertOnce(true)
@@ -403,8 +403,14 @@ class TSNotificationProvider @Inject constructor(
         return true
     }
 
+    override fun getNotificationChannelInfo(): MediaNotification.Provider.NotificationChannelInfo {
+        return MediaNotification.Provider.NotificationChannelInfo(CHANNEL_ID, CHANNEL_NAME)
+    }
+
     companion object {
         val mHandler by lazy { Handler(Looper.getMainLooper()) }
         const val TAG = "TuanDv"
+        const val CHANNEL_ID = "123"
+        const val CHANNEL_NAME = "TsPodcast"
     }
 }

--- a/sharedPlayer/src/main/java/tss/t/sharedplayer/service/PlayerSessionService.kt
+++ b/sharedPlayer/src/main/java/tss/t/sharedplayer/service/PlayerSessionService.kt
@@ -44,10 +44,10 @@ class PlayerSessionService() : MediaSessionService() {
             .setShowPlayButtonIfPlaybackIsSuppressed(true)
             .build()
         val channel = NotificationChannelCompat.Builder(
-            "123",
+            TSNotificationProvider.CHANNEL_ID,
             NotificationManagerCompat.IMPORTANCE_DEFAULT
         )
-            .setName("TsPodcast")
+            .setName(TSNotificationProvider.CHANNEL_NAME)
             .setDescription("TsPodcast app")
             .setVibrationEnabled(false)
             .setShowBadge(true)


### PR DESCRIPTION
Google Play requires new apps and app updates to target API 36 from August 31, 2026. The app was on compileSdk/targetSdk 35.

Toolchain:
- compileSdk/targetSdk 35 -> 36, AGP 8.11.0 -> 8.13.2, Gradle 8.13 -> 8.14.3. Stays on the AGP 8 line; API 37 needs AGP 9 + Gradle 9, a much larger migration (built-in Kotlin, new DSL, non-final R class) and Play does not require it yet.
- Pin securedToken's ndkVersion to 27.0.12077973 so the mandatory 16 KB page alignment is reproducible rather than floating with the AGP default.
- Enable core library desugaring in :app, now required by media3's IMA extension and the IMA SDK.
- Pin the applovin-quality-service plugin to 5.12.9 instead of "+", so a bytecode-rewriting plugin can no longer change version between builds.

Dependencies bumped to the newest versions that still support compileSdk 36 (AndroidX moved to compileSdk 37 during the April 2026 alpha cycle, so the very latest releases are deliberately not used):
- Compose BOM 2025.06.01 -> 2026.06.01 (ui 1.11.4, material3 1.4.0), and the hardcoded material3/material/icons pins dropped so the BOM manages them
- core-ktx 1.18.0, activity 1.13.0, navigation 2.9.8, lifecycle 2.10.0, media3 1.10.1, room 2.8.4, collection 1.6.0, security-crypto 1.1.0
- Firebase BOM 33.16.0 -> 34.17.0, which removes the -ktx artifacts, so the affected imports move to their non-ktx equivalents
- AppLovin 13.6.4, Facebook 18.3.0, and the Google Services / Crashlytics / App Distribution plugins

API-level behaviour work:
- media3 1.10.1 renamed createMediaActionPendingIntent to take an Int and added MediaNotification.Provider.getNotificationChannelInfo(); the channel id and name are now shared constants instead of literals in two files.
- material3 1.4.0 replaced Modifier.pullToRefreshIndicator with the PullToRefreshDefaults.IndicatorBox composable.
- Compose 1.11 no longer exposes material-icons transitively through material, so samples and featureOnboarding declare it directly.

Edge-to-edge is enforced at targetSdk 36 with no opt-out, so the insets had to be correct before the bump:
- rememberStatusBarHeight() cached the inset in a keyless remember, freezing whatever the first frame reported (often 0 under edge-to-edge) and never updating on rotation. It now reads the inset live.
- enableEdgeToEdge also declares navigationBarStyle.

Predictive back is on by default at targetSdk 36:
- The OnBackPressedCallback was registered without a LifecycleOwner, so it was never removed and accumulated on every activity recreation.
- Exiting now disables the callback and re-dispatches, letting the platform run its back-to-home animation instead of calling finish().

Permissions:
- POST_NOTIFICATIONS was declared in three manifests but never requested, so media and FCM notifications were invisible on fresh installs since API 33.
- Drop RECORD_AUDIO and ACCESS_FINE/COARSE_LOCATION, which were declared but never used anywhere, and the requestLegacyExternalStorage no-op.

Also fixes the four lint errors the new SDK and Compose versions surfaced, and stops tracking .kotlin compiler session markers.

Verified on an API 36 emulator with the release build: onboarding, live podcast data, playback as a mediaPlayback foreground service, the media notification, background playback, rotation, and back/exit navigation, with no crashes. All four native libraries are 16 KB aligned.